### PR TITLE
Add prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An extended version of window.fetch with interceptors and configurable instances",
   "main": "dist/fetch-it.js",
   "scripts": {
+    "prepublish": "npm run build",
     "build": "rm -rf dist && $(npm bin)/webpack",
     "test": "$(npm bin)/karma start --single-run"
   },


### PR DESCRIPTION
This runs before `npm publish` and before `npm link`. It may save you from
accidentally pushing a bad version to npm, and it lets other developers
contribute more easily.

```
cd ~/repos/fetch-it
npm link

cd ~/repos/my-other-project
# This installs the user's fork of fetch-it, so they can verify their changes work in their own project.
npm link fetch-it
```

https://docs.npmjs.com/cli/link